### PR TITLE
Refactor + Open discussion regarding CharDet's inaccuracies.

### DIFF
--- a/gigo.gemspec
+++ b/gigo.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency     'ensure_valid_encoding', '~> 0.5.3'
   gem.add_development_dependency 'appraisal'
   gem.add_development_dependency 'rake'
-  gem.add_development_dependency 'minitest'
+  gem.add_development_dependency 'minitest', '~> 4.7.4'
   gem.add_development_dependency 'minitest-emoji'
 end

--- a/test/cases/gigo_transcoders_test.rb
+++ b/test/cases/gigo_transcoders_test.rb
@@ -1,0 +1,45 @@
+#encoding: utf-8
+require 'test_helper'
+
+module GIGO
+  class BaseTest < TestCase
+    include GIGO::Transcoders
+
+    def self.test_transcoder(transcoder, input, output, options = {})
+      input = input.dup.force_encoding(input.encoding)
+      errant_encoding = options[:errant_encoding]
+      output_encoding = options[:output_encoding] || output.encoding
+
+      describe "#{transcoder.name}" do
+        it "detects #{input.encoding}#{errant_encoding && " mislabed as #{errant_encoding}"} and transcodes to #{output_encoding}" do
+          input.force_encoding(errant_encoding) unless errant_encoding.nil?
+          GIGO.load(input, [ transcoder ]).must_equal output
+        end
+      end
+    end
+
+    data_medico_utf8 =      "Med\u00EDco".force_encoding('UTF-8')
+    data_medico_iso88591 =  "Med\xEDco".force_encoding('iso8859-1')
+    data_medico_unknown =   "Med\uFFFDco".force_encoding('UTF-8')
+
+    [ [ ActiveSupportMultibyteTranscoder, data_medico_iso88591,   data_medico_utf8 ],
+      [ CharDetTranscoder,                data_medico_iso88591,   data_medico_utf8 ],
+      [ BlindTranscoder,                  data_medico_iso88591,   data_medico_utf8 ],
+
+      [ ActiveSupportMultibyteTranscoder, data_medico_iso88591,   data_medico_utf8,     :errant_encoding => 'US-ASCII' ],
+      [ CharDetTranscoder,                data_medico_iso88591,   data_medico_utf8,     :errant_encoding => 'US-ASCII' ],
+      [ BlindTranscoder,                  data_medico_iso88591,   data_medico_unknown,  :errant_encoding => 'US-ASCII' ],
+
+      [ ActiveSupportMultibyteTranscoder, data_medico_utf8,       data_medico_utf8,     :errant_encoding => 'US-ASCII' ],
+
+      # This will fail because CharDet misinterprets as ISO8859-2
+      [ CharDetTranscoder,                data_medico_utf8,       data_medico_utf8,     :errant_encoding => 'US-ASCII' ],
+      
+      # This would never be expected to pass.  Included for the sake of completeness.
+      # [ BlindTranscoder,                  data_medico_utf8,       data_medico_unknown,  :errant_encoding => 'US-ASCII' ],
+    ].each do |test_config|
+      test_transcoder(*test_config)
+    end
+
+  end
+end


### PR DESCRIPTION
I set out to accomplish one goal, and ended up killing two birds with one stone.  There is a significant refactor here that has merit regardless of any decisions reached about CharDet.  That said, my primary goal here is to provide concrete proof that CharDet is a risky fallback option behind ActiveSupport::Multibyte.

Running the test cases for this branch will yield one failing test.  When asked to detect the encoding for a string whose actual encoding is UTF-8, but whose "force_encoding" is US-ASCII, CharDet tells us that the encoding is ISO-8859-2 and the resulting transcode results in garbage.

I'm calling out this scenario because it is an ongoing occurrence in RFE.  We have at least one case where RFE and the backend both write to the same column.  RFE writes UTF-8.  The backend writes ISO-8859-1.  When I attempted to mitigate this with CharDet, it detected them both as ISO-8859-2, resulting in garbage after transcoding RFE's data, and a technically identical string in the backend's data.

Thankfully, ActiveSupport::Multibyte seems to do the right thing in all of my test cases, so CharDet's likelihood of ever being used is extremely low.  However, in the cases where it does wind up in use, it produces less favorable results than a simple blind transcoding with no attempt at detection.
